### PR TITLE
Complete partially-matched argument

### DIFF
--- a/R/supercells.R
+++ b/R/supercells.R
@@ -145,7 +145,7 @@ run_slic_chunks = function(ext, x, step, compactness, dist_type,
   ext_x = terra::ext(x)
   mat = dim(x)[1:2]
   mode(mat) = "integer"
-  vals = as.matrix(terra::as.data.frame(x, cell = FALSE, na.rm = FALSE))
+  vals = as.matrix(terra::as.data.frame(x, cells = FALSE, na.rm = FALSE))
   mode(vals) = "double"
 
   if (!is.null(transform)){


### PR DESCRIPTION
Thanks for the package! I've been enjoying using it so far :smile: 

This PR "completes" a partially matched argument in `terra::as.data.frame()` (from `cell` -> `cells` -- https://rdrr.io/cran/terra/man/as.data.frame.html). This was causing a bit of noise with `warnPartialMatchArgs` set.