### PR TITLE
 Avoid colour conversion error with 3+ bands rasters

### DIFF
--- a/R/supercells.R
+++ b/R/supercells.R
@@ -150,7 +150,7 @@ run_slic_chunks = function(ext, x, step, compactness, dist_name,
 
   # drop further layers (e.g. alpha band)
   if( nlyr(x) > 3){
-    x = subset(rgb, 1:3)
+    x = subset(x, 1:3)
     warning("The provided raster presents more than the expected channels: only the first three were kept")
   }
   

--- a/R/supercells.R
+++ b/R/supercells.R
@@ -147,12 +147,6 @@ run_slic_chunks = function(ext, x, step, compactness, dist_name,
   if (is.character(x)){
     x = terra::rast(x)
   }
-
-  # drop further layers (e.g. alpha band)
-  if( nlyr(x) > 3){
-    x = subset(x, 1:3)
-    warning("The provided raster presents more than the expected channels: only the first three were kept")
-  }
   
   # crops the input to the chunk extent
   x = x[ext[1]:ext[2], ext[3]:ext[4], drop = FALSE]
@@ -163,6 +157,10 @@ run_slic_chunks = function(ext, x, step, compactness, dist_name,
   # transforms the input to LAB color space if transform = "to_LAB"
   if (!is.null(transform)){
     if (transform == "to_LAB"){
+      if (ncol(vals) > 3) {
+        vals = vals[, 1:3]
+        warning("The provided raster has more than three layers: only the first three were kept for calculations", call. = FALSE)
+      }
       vals = vals / 255
       vals = grDevices::convertColor(vals, from = "sRGB", to = "Lab")
     }


### PR DESCRIPTION
I just stumbled upon an issue with an ortho image I had, making use of the experimental `to_LAB` parameter.
If more than 3 bands are provided (e.g. in my case an alpha band), `grDevices::convertColor `returns a not-so-informative error `"Error in dogamma(x) %*% M : non-conformable arguments"`.
An alternative could be to remove the `subset` and to convert the `warning` to a `stop` (but more informative about what's wrong) and let the user take care of providing a clean 3 bands raster.