### PR TITLE
Avoid implicit conversion from `sexp` to `double`

### DIFF
--- a/src/create_connectivity.cpp
+++ b/src/create_connectivity.cpp
@@ -137,7 +137,7 @@ void Slic::create_connectivity(doubles_matrix<> vals, cpp11::function avg_fun_fu
           new_centers_vals[c_id][nval] = mean(new_c_id_centers_vals[nval]);
         } else if (avg_fun_name.empty()){
           // use user-defined function
-          new_centers_vals[c_id][nval] = avg_fun_fun(new_c_id_centers_vals[nval]);
+          new_centers_vals[c_id][nval] = cpp11::as_cpp<double>(avg_fun_fun(new_c_id_centers_vals[nval]));
         }
       }
     }

--- a/src/distances.cpp
+++ b/src/distances.cpp
@@ -15,7 +15,7 @@ double get_vals_dist(vector<double>& values1, vector<double>& values2,
   } else if (dist_name != ""){
     return custom_distance(values1, values2, dist_name);
   } else {
-    return dist_fun(values1, values2);
+    return cpp11::as_cpp<double>(dist_fun(values1, values2));
   }
 }
 
@@ -125,5 +125,5 @@ double custom_distance(vector<double>& values1, vector<double>& values2, std::st
   double p = NA_REAL;
   bool testNA = false;
   std::string unit = "log2";
-  return single_distance(values1, values2, dist_name, p, testNA, unit);
+  return cpp11::as_cpp<double>(single_distance(values1, values2, dist_name, p, testNA, unit));
 }

--- a/src/generate_superpixels.cpp
+++ b/src/generate_superpixels.cpp
@@ -106,7 +106,7 @@ void Slic::generate_superpixels(integers mat, doubles_matrix<> vals, double step
           } else if (avg_fun_name == "mean2"){
             centers_vals[c_id][nval] = mean(centers_vals_c_id[nval]);
           } else if (avg_fun_name.empty()){
-            centers_vals[c_id][nval] = avg_fun_fun(centers_vals_c_id[nval]);
+            centers_vals[c_id][nval] = cpp11::as_cpp<double>(avg_fun_fun(centers_vals_c_id[nval]));
           }
         }
       }


### PR DESCRIPTION
cpp11 currently allows some somewhat scary implicit conversions between `sexp` and the 3 types `bool`, `size_t`, and `double`. These are unchecked conversions, and we'd like to remove them:
https://github.com/r-lib/cpp11/pull/390/

The recommended way is to use `cpp11::as_cpp<double>()`, which checks the type and length before performing the conversion, and is also explicit, which is a good thing for this kind of conversion.

I'm not going to remove these in the upcoming version of cpp11, but we will in the next after that