### PR TITLE
Update supercells documentation.R

### DIFF
--- a/R/supercells.R
+++ b/R/supercells.R
@@ -10,7 +10,7 @@
 #' A compactness value depends on the range of input cell values and selected distance measure.
 #' @param dist_fun A distance function. Currently implemented distance functions are `"euclidean"`, `"jsd"`, `"dtw"` (dynamic time warping), name of any distance function from the `philentropy` package (see [philentropy::getDistMethods()]; "log2" is used in this case), or any user defined function accepting two vectors and returning one value. Default: `"euclidean"`
 #' @param avg_fun An averaging function - how the values of the supercells' centers are calculated?
-#' It accepts any fitting R function (e.g., `base::mean()` or `stats::median()`) or one of internally implemented `"mean"` and `"median"`. Default: `"mean"`
+#' It accepts any fitting R function (e.g., `"base::mean()"` or `"stats::median()"`) or one of internally implemented `"mean"` and `"median"`. Default: `"mean"`
 #' @param clean Should connectivity of the supercells be enforced?
 #' @param iter The number of iterations performed to create the output.
 #' @param minarea Specifies the minimal size of a supercell (in cells). Only works when `clean = TRUE`.


### PR DESCRIPTION
Hi,
I was willing to test some more averaging functions but I noticed that, differently from the internally implemented functions, R functions like plain `base::mean()` or `stats::median()` return the following error:

`Error in median.default() : argument "x" is missing, with no default`

I thought it might have been a problem with the function interpreter but, testing a bit, I realised that it was related to the missed use of double quotes. This update targets this "issue" for users' clarity due to the fact that, within other packages, functions are interpreted without quotes and my above experience might lead others to erroneous interpretation of the help info.
HTH!